### PR TITLE
Check partition boundaries in GPT.write_into()

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1511,23 +1511,24 @@ mod test {
     #[test]
     fn determine_partition_alignment() {
         fn test(ss: u64, align: u64) {
-            let data = vec![0; ss as usize * align as usize * 10];
+            let data = vec![0; ss as usize * align as usize * 21];
             let mut cur = io::Cursor::new(data);
             let mut gpt = GPT::new_from(&mut cur, ss, [1; 16]).unwrap();
             gpt[1] = GPTPartitionEntry {
                 attribute_bits: 0,
-                ending_lba: 2 * align,
+                ending_lba: 6 * align,
                 partition_name: "".into(),
                 partition_type_guid: [1; 16],
-                starting_lba: align,
+                // start at least at first_usable_lba in smallest case
+                starting_lba: 5 * align,
                 unique_partition_guid: [1; 16],
             };
             gpt[2] = GPTPartitionEntry {
                 attribute_bits: 0,
-                ending_lba: 8 * align,
+                ending_lba: 16 * align,
                 partition_name: "".into(),
                 partition_type_guid: [1; 16],
-                starting_lba: 4 * align,
+                starting_lba: 8 * align,
                 unique_partition_guid: [2; 16],
             };
             gpt.write_into(&mut cur).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,7 @@ impl GPTHeader {
             self.primary_lba = len - 1;
         }
         self.last_usable_lba = len - partition_array_size - 1 - 1;
-        self.first_usable_lba = self.partition_entry_lba + partition_array_size;
+        self.first_usable_lba = 2 + partition_array_size;
 
         Ok(())
     }
@@ -1383,11 +1383,15 @@ mod test {
             let mut gpt = GPT::read_from(&mut cur, ss).unwrap();
             assert_eq!(gpt.header.backup_lba, 1);
             let partition_entry_lba = gpt.header.partition_entry_lba;
+            let first_usable_lba = gpt.header.first_usable_lba;
+            let last_usable_lba = gpt.header.last_usable_lba;
             gpt.write_into(&mut cur).unwrap();
             let mut gpt = GPT::read_from(&mut cur, ss).unwrap();
             assert_eq!(gpt.header.primary_lba, 1);
             assert_eq!(gpt.header.backup_lba, backup_lba);
             assert_eq!(gpt.header.partition_entry_lba, 2);
+            assert_eq!(gpt.header.first_usable_lba, first_usable_lba);
+            assert_eq!(gpt.header.last_usable_lba, last_usable_lba);
 
             gpt.header.crc32_checksum = 1;
             cur.seek(SeekFrom::Start(ss)).unwrap();


### PR DESCRIPTION
Fail with `InvalidPartitionBoundaries` if any partition starts before `first_usable_lba`, ends after `last_usable_lba`, ends before it starts, or overlaps with another partition.

Also fix one incorrect test and one bug found by the new checks.