### PR TITLE
Include test fixtures in packaged crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/cecton/gptman"
 homepage = "https://github.com/cecton/gptman"
 documentation = "https://docs.rs/gptman"
 readme = "README.md"
-include = ["src/**/*.rs", "README.md", "LICENSE.Apache-2.0", "LICENSE.MIT"]
+include = ["src/**/*.rs", "tests/fixtures/*.img", "README.md", "LICENSE.Apache-2.0", "LICENSE.MIT"]
 keywords = ["gpt", "partition", "table", "filesystem", "disk"]
 categories = ["command-line-utilities"]
 


### PR DESCRIPTION
The Fedora RPM specfile runs the tests after building the crate, and some of these fail without the fixtures.

Fixes: 4a9e304aaa5e ("Change licensing to MIT OR Apache-2.0")