### PR TITLE
Switch to thiserror & update dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,20 +16,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v2
 
-      - name: Get main commit hash
-        id: main_commit
-        run: echo "::set-output name=hash::$(git rev-parse origin/main)"
-
-      - name: Cache target, rustup and cargo registry
-        id: cache-target
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.rustup
-            ~/.cargo/registry
-            ~/.cargo/bin
-            target
-          key: main-${{ steps.main_commit.outputs.hash }}
+      - uses: Swatinem/rust-cache@v1
 
       - name: cargo test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,8 +10,36 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  cargo-test:
+  test-linux:
     runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace
+
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - uses: Swatinem/rust-cache@v1
+
+      - name: cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace
+
+  test-macos:
+    runs-on: macos-latest
     steps:
       - name: Checkout source
         uses: actions/checkout@v2

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,23 +14,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v2
 
-      - name: Get main commit hash
-        id: main_commit
-        run: |
-          git fetch origin main
-          echo "::set-output name=hash::$(git rev-parse origin/main)"
-
-      - name: Cache target, rustup and cargo registry
-        id: cache-target
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.rustup
-            ~/.cargo/registry
-            ~/.cargo/bin
-            target
-          key: ${{ github.event.issue.number }}-${{ runner.os }}-pr
-          restore-keys: main-${{ steps.main_commit.outputs.hash }}
+      - uses: Swatinem/rust-cache@v1
 
       - name: cargo test
         uses: actions-rs/cargo@v1
@@ -56,23 +40,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v2
 
-      - name: Get main commit hash
-        id: main_commit
-        run: |
-          git fetch origin main
-          echo "::set-output name=hash::$(git rev-parse origin/main)"
-
-      - name: Cache target, rustup and cargo registry
-        id: cache-target
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.rustup
-            ~/.cargo/registry
-            ~/.cargo/bin
-            target
-          key: ${{ github.event.issue.number }}-${{ runner.os }}-pr
-          restore-keys: main-${{ steps.main_commit.outputs.hash }}
+      - uses: Swatinem/rust-cache@v1
 
       - name: cargo test
         uses: actions-rs/cargo@v1
@@ -86,23 +54,7 @@ jobs:
       - name: Checkout source
         uses: actions/checkout@v2
 
-      - name: Get main commit hash
-        id: main_commit
-        run: |
-          git fetch origin main
-          echo "::set-output name=hash::$(git rev-parse origin/main)"
-
-      - name: Cache target, rustup and cargo registry
-        id: cache-target
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.rustup
-            ~/.cargo/registry
-            ~/.cargo/bin
-            target
-          key: ${{ github.event.issue.number }}-${{ runner.os }}-pr
-          restore-keys: main-${{ steps.main_commit.outputs.hash }}
+      - uses: Swatinem/rust-cache@v1
 
       - name: cargo test
         uses: actions-rs/cargo@v1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -47,3 +47,59 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: -- -D warnings
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Get main commit hash
+        id: main_commit
+        run: echo "::set-output name=hash::$(git rev-parse origin/main)"
+
+      - name: Cache target, rustup and cargo registry
+        id: cache-target
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.rustup
+            ~/.cargo/registry
+            ~/.cargo/bin
+            target
+          key: ${{ github.event.issue.number }}-${{ runner.os }}-pr
+          restore-keys: main-${{ steps.main_commit.outputs.hash }}
+
+      - name: cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace
+
+  osx:
+    runs-on: osx-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v2
+
+      - name: Get main commit hash
+        id: main_commit
+        run: echo "::set-output name=hash::$(git rev-parse origin/main)"
+
+      - name: Cache target, rustup and cargo registry
+        id: cache-target
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.rustup
+            ~/.cargo/registry
+            ~/.cargo/bin
+            target
+          key: ${{ github.event.issue.number }}-${{ runner.os }}-pr
+          restore-keys: main-${{ steps.main_commit.outputs.hash }}
+
+      - name: cargo test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --workspace

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -16,7 +16,9 @@ jobs:
 
       - name: Get main commit hash
         id: main_commit
-        run: echo "::set-output name=hash::$(git rev-parse origin/main)"
+        run: |
+          git fetch origin main
+          echo "::set-output name=hash::$(git rev-parse origin/main)"
 
       - name: Cache target, rustup and cargo registry
         id: cache-target
@@ -56,7 +58,9 @@ jobs:
 
       - name: Get main commit hash
         id: main_commit
-        run: echo "::set-output name=hash::$(git rev-parse origin/main)"
+        run: |
+          git fetch origin main
+          echo "::set-output name=hash::$(git rev-parse origin/main)"
 
       - name: Cache target, rustup and cargo registry
         id: cache-target
@@ -76,15 +80,17 @@ jobs:
           command: test
           args: --workspace
 
-  osx:
-    runs-on: osx-latest
+  macos:
+    runs-on: macos-latest
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
 
       - name: Get main commit hash
         id: main_commit
-        run: echo "::set-output name=hash::$(git rev-parse origin/main)"
+        run: |
+          git fetch origin main
+          echo "::set-output name=hash::$(git rev-parse origin/main)"
 
       - name: Cache target, rustup and cargo registry
         id: cache-target

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,7 +8,7 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  cargo-test-and-lint:
+  test-and-lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source
@@ -34,7 +34,7 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           args: -- -D warnings
 
-  windows:
+  test-windows:
     runs-on: windows-latest
     steps:
       - name: Checkout source
@@ -48,7 +48,7 @@ jobs:
           command: test
           args: --workspace
 
-  macos:
+  test-macos:
     runs-on: macos-latest
     steps:
       - name: Checkout source

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,6 +105,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
 
 [[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
 name = "clap"
 version = "2.33.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,7 +147,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
 dependencies = [
  "autocfg",
- "cfg-if",
+ "cfg-if 0.1.10",
  "lazy_static",
 ]
 
@@ -162,7 +168,7 @@ version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13aea89a5c93364a98e9b37b2fa237effbb694d5cfe01c5b70941f7eb087d5e3"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "dirs-sys",
 ]
 
@@ -178,20 +184,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "err-derive"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22deed3a8124cff5fa835713fa105621e43bbdc46690c3a6b68328a012d350d4"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -203,9 +195,20 @@ version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
- "wasi",
+ "wasi 0.9.0+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9495705279e7140bf035dde1f6e750c162df8b625267cd52cc44e0b156732c8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "wasi 0.10.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -214,16 +217,15 @@ version = "0.7.3"
 dependencies = [
  "ansi_term 0.12.1",
  "bincode",
- "clap",
  "crc",
- "err-derive",
  "lazy_static",
  "linefeed",
  "nix 0.18.0",
  "pad",
- "rand",
+ "rand 0.8.2",
  "serde",
  "structopt",
+ "thiserror",
  "unicode-width",
 ]
 
@@ -298,7 +300,7 @@ checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
  "void",
 ]
@@ -311,7 +313,7 @@ checksum = "83450fe6a6142ddd95fb064b746083fc4ef1705fe81f64a64e1d4b39f54a1055"
 dependencies = [
  "bitflags",
  "cc",
- "cfg-if",
+ "cfg-if 0.1.10",
  "libc",
 ]
 
@@ -360,7 +362,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
 dependencies = [
  "phf_shared",
- "rand",
+ "rand 0.7.3",
 ]
 
 [[package]]
@@ -404,9 +406,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.19"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04f5f085b5d71e2188cb8271e5da0161ad52c3f227a661a3c135fdf28e258b12"
+checksum = "1e0704ee1a7e00d7bb417d0770ea303c1bccbabf0ef1667dae92b5967f5f8a71"
 dependencies = [
  "unicode-xid",
 ]
@@ -426,12 +428,24 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.14",
  "libc",
- "rand_chacha",
- "rand_core",
- "rand_hc",
+ "rand_chacha 0.2.2",
+ "rand_core 0.5.1",
+ "rand_hc 0.2.0",
  "rand_pcg",
+]
+
+[[package]]
+name = "rand"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18519b42a40024d661e1714153e9ad0c3de27cd495760ceb09710920f1098b1e"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.0",
+ "rand_core 0.6.1",
+ "rand_hc 0.3.0",
 ]
 
 [[package]]
@@ -441,7 +455,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12735cf05c9e10bf21534da50a147b924d555dc7a547c42e6bb2d5b6017ae0d"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -450,7 +474,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.14",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c026d7df8b298d90ccbbc5190bd04d85e159eaf5576caeacf8741da93ccbd2e5"
+dependencies = [
+ "getrandom 0.2.2",
 ]
 
 [[package]]
@@ -459,7 +492,16 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
+]
+
+[[package]]
+name = "rand_hc"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3190ef7066a446f2e7f42e239d161e905420ccab01eb967c9eb27d21b2322a73"
+dependencies = [
+ "rand_core 0.6.1",
 ]
 
 [[package]]
@@ -468,7 +510,7 @@ version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
- "rand_core",
+ "rand_core 0.5.1",
 ]
 
 [[package]]
@@ -483,7 +525,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
 dependencies = [
- "getrandom",
+ "getrandom 0.1.14",
  "redox_syscall",
  "rust-argon2",
 ]
@@ -498,17 +540,6 @@ dependencies = [
  "blake2b_simd",
  "constant_time_eq",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "rustversion"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9bdc5e856e51e685846fb6c13a1f5e5432946c2c90501bdc76a1319f19e29da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -584,24 +615,12 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "1.0.36"
+version = "1.0.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cdb98bcb1f9d81d07b536179c269ea15999b5d14ea958196413869445bb5250"
+checksum = "07cb8b1b4ebf86a89ee88cbd201b022b94138c623644d035185c84d3f41b7e66"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b834f2d66f734cb897113e34aaff2f1ab4719ca946f9a7358dba8f8064148701"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
  "unicode-xid",
 ]
 
@@ -625,6 +644,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
  "unicode-width",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76cc616c6abf8c8928e2fdcc0dbfab37175edd8fb49a4641066ad1364fdab146"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9be73a2caec27583d0046ef3796c3794f868a5bc813db689eed00c7631275cd1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -683,6 +722,12 @@ name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
+
+[[package]]
+name = "wasi"
+version = "0.10.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93c6c3420963c5c64bca373b25e77acb562081b9bb4dd5bb864187742186cea9"
 
 [[package]]
 name = "winapi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,9 +26,9 @@ checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
 
 [[package]]
 name = "arrayvec"
-version = "0.5.1"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff77d8686867eceff3105329d4698d96c2391c176d5d03adc90c7389162b5b8"
+checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "atty"
@@ -43,15 +43,15 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8aac770f1885fd7e387acedd76065302551364496e46b3dd00860b2f8359b9d"
+checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
 name = "base64"
-version = "0.11.0"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41b7ea54a0c9d92199de89e20e58d49f02f8e699814ef3fdf266f6f748d15c7"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 
 [[package]]
 name = "bincode"
@@ -71,9 +71,9 @@ checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
 name = "blake2b_simd"
-version = "0.5.10"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8fb2d74254a3a0b5cac33ac9f8ed0e44aa50378d9dbb2e5d83bd21ed1dc2c8a"
+checksum = "afa748e348ad3be8263be728124b24a24f268266f6f5d58af9d75f6a40b5c587"
 dependencies = [
  "arrayref",
  "arrayvec",
@@ -88,15 +88,15 @@ checksum = "39092a32794787acd8525ee150305ff051b0aa6cc2abaf193924f5ab05425f39"
 
 [[package]]
 name = "byteorder"
-version = "1.3.4"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08c48aae112d48ed9f069b33538ea9e3e90aa263cfa3d1c24309612b1f7472de"
+checksum = "ae44d1a3d5a19df61dd0c8beb138458ac2a53a7ac09eba97d55592540004306b"
 
 [[package]]
 name = "cc"
-version = "1.0.58"
+version = "1.0.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a06fb2e53271d7c279ec1efea6ab691c35a2ae67ec0d91d7acec0caf13b518"
+checksum = "4c0496836a84f8d0495758516b8621a622beb77c0fed418570e50764093ced48"
 
 [[package]]
 name = "cfg-if"
@@ -112,9 +112,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.2"
+version = "2.33.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10040cdf04294b565d9e0319955430099ec3813a64c952b86a41200ad714ae48"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
 dependencies = [
  "ansi_term 0.11.0",
  "atty",
@@ -142,12 +142,12 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-utils"
-version = "0.7.2"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3c7c73a2d1e9fc0886a08b93e98eb643461230d5f1925e4036204d5f2e261a8"
+checksum = "02d96d1e189ef58269ebe5b97953da3274d83a93af647c2ddd6f9dab28cedb8d"
 dependencies = [
  "autocfg",
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "lazy_static",
 ]
 
@@ -191,11 +191,11 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "getrandom"
-version = "0.1.14"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7abc8dd8451921606d809ba32e95b6111925cd2906060d2dcc29c070220503eb"
+checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.0",
  "libc",
  "wasi 0.9.0+wasi-snapshot-preview1",
 ]
@@ -231,18 +231,18 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
+checksum = "87cbf45460356b7deeb5e3415b5563308c0a9b057c85e12b06ad551f98d0a6ac"
 dependencies = [
  "unicode-segmentation",
 ]
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.15"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3deed196b6e7f9e44a2ae8d94225d80302d81208b1bb673fd21fe634645c85a9"
+checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
@@ -255,9 +255,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.74"
+version = "0.2.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2f02823cf78b754822df5f7f268fb59822e7296276d3e069d8e8cb26a14bd10"
+checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
 name = "linefeed"
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.3.3"
+version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3728d817d99e5ac407411fa471ff9800a778d88a24685968b36824eaf4bee400"
+checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
 
 [[package]]
 name = "mortal"
@@ -376,9 +376,9 @@ dependencies = [
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.8"
+version = "0.2.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "237a5ed80e274dbc66f86bd59c1e25edc039660be53194b5fe0a482e0f2612ea"
+checksum = "ac74c624d6b2d21f425f752262f42188365d7b8ff1aff74c82e45136510a4857"
 
 [[package]]
 name = "proc-macro-error"
@@ -415,9 +415,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa563d17ecb180e500da1cfd2b028310ac758de548efdd203e18f283af693f37"
+checksum = "991431c3519a3f36861882da93630ce66b52918dcf1b8e2fd66b397fc96f28df"
 dependencies = [
  "proc-macro2",
 ]
@@ -428,7 +428,7 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
 dependencies = [
- "getrandom 0.1.14",
+ "getrandom 0.1.16",
  "libc",
  "rand_chacha 0.2.2",
  "rand_core 0.5.1",
@@ -474,7 +474,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
 dependencies = [
- "getrandom 0.1.14",
+ "getrandom 0.1.16",
 ]
 
 [[package]]
@@ -521,20 +521,20 @@ checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
 name = "redox_users"
-version = "0.3.4"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09b23093265f8d200fa7b4c2c76297f47e681c655f6f1285a8780d6a022f7431"
+checksum = "de0737333e7a9502c789a36d7c7fa6092a49895d4faa31ca5df163857ded2e9d"
 dependencies = [
- "getrandom 0.1.14",
+ "getrandom 0.1.16",
  "redox_syscall",
  "rust-argon2",
 ]
 
 [[package]]
 name = "rust-argon2"
-version = "0.7.0"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bc8af4bda8e1ff4932523b94d3dd20ee30a87232323eda55903ffd71d2fb017"
+checksum = "4b18820d944b33caa75a71378964ac46f58517c92b6ae5f762636247c09e78fb"
 dependencies = [
  "base64",
  "blake2b_simd",
@@ -544,18 +544,18 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.116"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96fe57af81d28386a513cbc6858332abc6117cfdb5999647c6444b8f43a370a5"
+checksum = "166b2349061381baf54a58e4b13c89369feb0ef2eaa57198899e2312aac30aab"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.116"
+version = "1.0.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f630a6370fd8e457873b4bd2ffdae75408bc291ba72be773772a4c2a065d9ae8"
+checksum = "0ca2a8cb5805ce9e3b95435e3765b7b553cecc762d938d409434338386cb5775"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -579,9 +579,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.4.1"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3757cb9d89161a2f24e1cf78efa0c1fcff485d18e3f55e0aa3480824ddaa0f3f"
+checksum = "fe0f37c9e8f3c5a4a66ad655a93c74daac4ad00c441533bf5c6e7990bb42604e"
 
 [[package]]
 name = "strsim"
@@ -591,9 +591,9 @@ checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 
 [[package]]
 name = "structopt"
-version = "0.3.16"
+version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de5472fb24d7e80ae84a7801b7978f95a19ec32cb1876faea59ab711eb901976"
+checksum = "5277acd7ee46e63e5168a80734c9f6ee81b1367a7d8772a2d765df2a3705d28c"
 dependencies = [
  "clap",
  "lazy_static",
@@ -602,9 +602,9 @@ dependencies = [
 
 [[package]]
 name = "structopt-derive"
-version = "0.4.9"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0eb37335aeeebe51be42e2dc07f031163fbabfa6ac67d7ea68b5c2f68d5f99"
+checksum = "5ba9cdfda491b814720b6b06e0cac513d922fc407582032e8706e9f137976f90"
 dependencies = [
  "heck",
  "proc-macro-error",
@@ -668,24 +668,33 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "0.3.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53953d2d3a5ad81d9f844a32f14ebb121f50b650cd59d0ee2a07cf13c617efed"
+checksum = "ccf8dbc19eb42fba10e8feaaec282fb50e2c14b2726d6301dbfeed0f73306a6f"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.13"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fb19cf769fa8c6a80a162df694621ebeb4dafb606470b2b2fce0be40a98a977"
+checksum = "a13e63ab62dbe32aeee58d1c5408d35c36c392bba5d9d3142287219721afe606"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83e153d1053cbb5a118eeff7fd5be06ed99153f00dbcd8ae310c5fb2b22edc0"
+checksum = "bb0d2e7be6ae3a5fa87eed5fb451aff96f2573d2694942e40543ae0bbe19c796"
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,19 +26,18 @@ name = "gptman"
 bincode = "1.3.1"
 serde = { version = "1.0.116", features = ["derive"] }
 crc = "1.0.0"
-err-derive = "0.2.4"
+thiserror = "1.0"
 lazy_static = { version = "1.2.0", optional = true }
 ansi_term = { version = "0.12", optional = true }
 pad = { version = "0.1", optional = true }
 unicode-width = { version = "0.1.8", optional = true }
-clap = { version = "2.33", optional = true }
 linefeed = { version = "0.6.0", optional = true }
-rand = { version = "0.7", optional = true }
+rand = { version = "0.8", optional = true }
 structopt = { version = "0.3", optional = true }
 
 [features]
 default = [ "cli" ]
-cli = [ "lazy_static", "ansi_term", "pad", "unicode-width", "clap", "linefeed", "rand", "structopt" ]
+cli = [ "lazy_static", "ansi_term", "pad", "unicode-width", "linefeed", "rand", "structopt" ]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = "0.18"

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -86,7 +86,7 @@ where
         "c" => copy_partition(gpt, &opt.device, ask)?,
         "D" => print_raw_data(gpt, &opt.device)?,
         "a" => change_alignment(gpt, ask)?,
-        "Z" => randomize(gpt)?,
+        "Z" => randomize(gpt),
         "s" => swap_partition_index(gpt, ask)?,
         "C" => copy_all_partitions(gpt, &opt.device, ask)?,
         x => println!("{}: unknown command", x),
@@ -850,14 +850,12 @@ where
     Ok(())
 }
 
-fn randomize(gpt: &mut GPT) -> Result<()> {
+fn randomize(gpt: &mut GPT) {
     gpt.header.disk_guid = generate_random_uuid();
 
     for (_, p) in gpt.iter_mut() {
         p.unique_partition_guid = generate_random_uuid();
     }
-
-    Ok(())
 }
 
 fn swap_partition_index<F>(gpt: &mut GPT, ask: &F) -> Result<()>

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -1,12 +1,12 @@
 use crate::attribute_bits::AttributeBits;
 use crate::error::*;
-use crate::gptman::{GPTPartitionEntry, GPT};
 use crate::opt::Opt;
 use crate::table::Table;
 use crate::types::PartitionTypeGUID;
 use crate::uuid::{convert_str_to_array, generate_random_uuid, UUID};
 #[cfg(target_os = "linux")]
 use gptman::linux::reread_partition_table;
+use gptman::{GPTPartitionEntry, GPT};
 use std::fs;
 use std::io::{Read, Seek, SeekFrom};
 use std::path::PathBuf;

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -1,12 +1,3 @@
-#[macro_use]
-extern crate lazy_static;
-#[macro_use]
-extern crate clap;
-extern crate gptman;
-extern crate linefeed;
-extern crate rand;
-extern crate structopt;
-
 mod attribute_bits;
 mod commands;
 mod error;

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -70,7 +70,7 @@ fn main() {
             Ok(command) => {
                 if command == "q" {
                     break;
-                } else if command != "" {
+                } else if !command.is_empty() {
                     match execute(command.as_str(), &opt, len, &mut gpt, &ask) {
                         Ok(false) => {}
                         Ok(true) => break,

--- a/src/cli/opt.rs
+++ b/src/cli/opt.rs
@@ -1,4 +1,5 @@
 use std::path::PathBuf;
+use structopt::clap::arg_enum;
 use structopt::StructOpt;
 
 arg_enum! {

--- a/src/cli/types.rs
+++ b/src/cli/types.rs
@@ -1,4 +1,5 @@
 use crate::uuid::{convert_str_to_array, UUID};
+use lazy_static::lazy_static;
 use std::collections::HashMap;
 
 lazy_static! {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,8 +70,6 @@
 
 #![deny(missing_docs)]
 
-#[macro_use]
-extern crate err_derive;
 #[cfg(target_os = "linux")]
 #[macro_use]
 extern crate nix;
@@ -87,6 +85,7 @@ use std::fmt;
 use std::io;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::ops::{Index, IndexMut};
+use thiserror::Error;
 
 /// Linux specific helpers
 #[cfg(target_os = "linux")]
@@ -99,64 +98,57 @@ const MAX_ALIGN: u64 = 16384;
 #[derive(Debug, Error)]
 pub enum Error {
     /// Derialization errors.
-    #[error(display = "deserialization failed")]
-    Deserialize(#[error(cause)] bincode::Error),
+    #[error("deserialization failed")]
+    Deserialize(#[from] bincode::Error),
     /// I/O errors.
-    #[error(display = "generic I/O error")]
-    Io(#[error(cause)] io::Error),
+    #[error("generic I/O error")]
+    Io(#[from] io::Error),
     /// An error that occurs when the signature of the GPT isn't what would be expected ("EFI
     /// PART").
-    #[error(display = "invalid signature")]
+    #[error("invalid signature")]
     InvalidSignature,
     /// An error that occurs when the revision of the GPT isn't what would be expected (00 00 01
     /// 00).
-    #[error(display = "invalid revision")]
+    #[error("invalid revision")]
     InvalidRevision,
     /// An error that occurs when the header's size (in bytes) isn't what would be expected (92).
-    #[error(display = "invalid header size")]
+    #[error("invalid header size")]
     InvalidHeaderSize,
     /// An error that occurs when the CRC32 checksum of the header doesn't match the expected
     /// checksum for the actual header.
-    #[error(display = "corrupted CRC32 checksum ({} != {})", _0, _1)]
+    #[error("corrupted CRC32 checksum ({0} != {1})")]
     InvalidChecksum(u32, u32),
     /// An error that occurs when the CRC32 checksum of the partition entries array doesn't match
     /// the expected checksum for the actual partition entries array.
-    #[error(
-        display = "corrupted partition entry array CRC32 checksum ({} != {})",
-        _0,
-        _1
-    )]
+    #[error("corrupted partition entry array CRC32 checksum ({0} != {1})")]
     InvalidPartitionEntryArrayChecksum(u32, u32),
     /// An error that occurs when reading a GPT from a file did not succeeded.
     ///
     /// The first argument is the error that occurred when trying to read the primary header.
     /// The second argument is the error that occurred when trying to read the backup header.
-    #[error(
-        display = "could not read primary header ({}) nor backup header ({})",
-        _0,
-        _1
-    )]
+    #[error("could not read primary header ({0}) nor backup header ({1})")]
     ReadError(Box<Error>, Box<Error>),
     /// An error that occurs when there is not enough space left on the table to continue.
-    #[error(display = "no space left")]
+    #[error("no space left")]
     NoSpaceLeft,
     /// An error that occurs when there are partitions with the same GUID in the same array.
-    #[error(display = "conflict of partition GUIDs")]
+    #[error("conflict of partition GUIDs")]
     ConflictPartitionGUID,
     /// An error that occurs when a partition has an invalid boundary.
     /// The end sector must be greater or equal to the start sector of the partition.
     /// Partitions must fit within the disk and must not overlap.
     #[error(
-        display = "invalid partition boundaries: partitions must have positive size, must not overlap, and must fit within the disk"
+        "invalid partition boundaries: partitions must have positive size, must not overlap, \
+        and must fit within the disk"
     )]
     InvalidPartitionBoundaries,
     /// An error that occurs when the user provide an invalid partition number.
     /// The partition number must be between 1 and `number_of_partition_entries` (usually 128)
     /// included.
-    #[error(display = "invalid partition number: {}", _0)]
+    #[error("invalid partition number: {0}")]
     InvalidPartitionNumber(u32),
     /// An operation that required to find a partition, was unable to find that partition.
-    #[error(display = "partition not found")]
+    #[error("partition not found")]
     PartitionNotFound,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -70,10 +70,6 @@
 
 #![deny(missing_docs)]
 
-#[cfg(target_os = "linux")]
-#[macro_use]
-extern crate nix;
-
 use bincode::{deserialize_from, serialize, serialize_into};
 use crc::{crc32, Hasher32};
 use serde::de::{SeqAccess, Visitor};

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -5,6 +5,8 @@ use std::os::unix::io::AsRawFd;
 use thiserror::Error;
 
 mod ioctl {
+    use nix::{ioctl_none, ioctl_read_bad};
+
     ioctl_read_bad!(blksszget, 0x1268, u64);
     ioctl_none!(blkrrpart, 0x12, 95);
 }

--- a/src/linux.rs
+++ b/src/linux.rs
@@ -2,6 +2,7 @@ use std::fs;
 use std::io;
 use std::os::linux::fs::MetadataExt;
 use std::os::unix::io::AsRawFd;
+use thiserror::Error;
 
 mod ioctl {
     ioctl_read_bad!(blksszget, 0x1268, u64);
@@ -15,19 +16,19 @@ const S_IFBLK: u32 = 0o60_000;
 #[derive(Debug, Error)]
 pub enum BlockError {
     /// An error that occurs when the metadata of the input file couldn't be retrieved
-    #[error(display = "failed to get metadata of device fd")]
-    Metadata(#[error(cause)] io::Error),
+    #[error("failed to get metadata of device fd")]
+    Metadata(#[from] io::Error),
     /// An error that occurs when the partition table could not be reloaded by the OS
-    #[error(display = "failed to reload partition table of device")]
-    RereadTable(#[error(cause)] nix::Error),
+    #[error("failed to reload partition table of device")]
+    RereadTable(#[from] nix::Error),
     /// An error that occurs when the sector size could not be retrieved from the OS
-    #[error(display = "failed to get the sector size of device")]
-    GetSectorSize(#[error(cause, no_from)] nix::Error),
+    #[error("failed to get the sector size of device: {0}")]
+    GetSectorSize(nix::Error),
     /// An error that occurs when an invalid return code has been received from an ioctl call
-    #[error(display = "invalid return value of ioctl ({} != 0)", _0)]
+    #[error("invalid return value of ioctl ({0} != 0)")]
     InvalidReturnValue(i32),
     /// An error that occurs when the file provided is not a block device
-    #[error(display = "not a block device")]
+    #[error("not a block device")]
     NotBlock,
 }
 


### PR DESCRIPTION
I'm switching from err-derive to thiserror because the developer of err-derive is soft deprecating err-derive. You can see it there: https://gitlab.com/torkleyy/err-derive/-/releases

This will probably require a bump in the major as I'm not sure the API of error will stay the same.

I would really love to have a review :heart: maybe @bgilbert or @mmstick can help? :pray: It's very small!