### PR TITLE
Depend on count-zeroes only for cli feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,11 +34,11 @@ unicode-width = { version = "0.1.8", optional = true }
 linefeed = { version = "0.6.0", optional = true }
 rand = { version = "0.8", optional = true }
 structopt = { version = "0.3", optional = true }
-count-zeroes = "0.2.0"
+count-zeroes = { version = "0.2.0", optional = true }
 
 [features]
 default = [ "cli" ]
-cli = [ "lazy_static", "ansi_term", "pad", "unicode-width", "linefeed", "rand", "structopt" ]
+cli = [ "lazy_static", "ansi_term", "pad", "unicode-width", "linefeed", "rand", "structopt", "count-zeroes" ]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = "0.22"


### PR DESCRIPTION
The library itself doesn't need it.