### PR TITLE
Replace structopt with clap 3.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,15 +4,6 @@ version = 3
 
 [[package]]
 name = "ansi_term"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
-dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "ansi_term"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
@@ -101,17 +92,41 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "2.33.3"
+version = "3.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+checksum = "47582c09be7c8b32c0ab3a6181825ababb713fde6fff20fc573a3870dd45c6a0"
 dependencies = [
- "ansi_term 0.11.0",
  "atty",
  "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
  "strsim",
+ "termcolor",
  "textwrap",
- "unicode-width",
- "vec_map",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a37c35f1112dad5e6e0b1adaff798507497a18fceeb30cceb3bae7d1427b9213"
+dependencies = [
+ "os_str_bytes",
 ]
 
 [[package]]
@@ -215,8 +230,9 @@ dependencies = [
 name = "gptman"
 version = "0.8.4"
 dependencies = [
- "ansi_term 0.12.1",
+ "ansi_term",
  "bincode",
+ "clap",
  "count-zeroes",
  "crc",
  "lazy_static",
@@ -225,19 +241,21 @@ dependencies = [
  "pad",
  "rand 0.8.4",
  "serde",
- "structopt",
  "thiserror",
  "unicode-width",
 ]
 
 [[package]]
-name = "heck"
-version = "0.3.3"
+name = "hashbrown"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d621efb26863f0e9924c6ac577e8275e5e6b77455db64ffa6c65c904e9e132c"
-dependencies = [
- "unicode-segmentation",
-]
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
@@ -246,6 +264,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -337,6 +365,12 @@ dependencies = [
  "memchr",
  "version_check",
 ]
+
+[[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
 
 [[package]]
 name = "pad"
@@ -615,33 +649,9 @@ checksum = "1ecab6c735a6bb4139c0caafd0cc3635748bbb3acf4550e8138122099251f309"
 
 [[package]]
 name = "strsim"
-version = "0.8.0"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
-
-[[package]]
-name = "structopt"
-version = "0.3.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40b9788f4202aa75c240ecc9c15c65185e6a39ccdeb0fd5d008b98825464c87c"
-dependencies = [
- "clap",
- "lazy_static",
- "structopt-derive",
-]
-
-[[package]]
-name = "structopt-derive"
-version = "0.4.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcb5ae327f9cc13b68763b5749770cb9e048a99bd9dfdfa58d0cf05d5f64afe0"
-dependencies = [
- "heck",
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn",
-]
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -652,6 +662,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -669,12 +688,9 @@ dependencies = [
 
 [[package]]
 name = "textwrap"
-version = "0.11.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
-dependencies = [
- "unicode-width",
-]
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
 
 [[package]]
 name = "thiserror"
@@ -721,12 +737,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8895849a949e7845e06bd6dc1aa51731a103c42707010a5b591c0038fb73385b"
-
-[[package]]
 name = "unicode-width"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -737,12 +747,6 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
-
-[[package]]
-name = "vec_map"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
 
 [[package]]
 name = "version_check"
@@ -783,6 +787,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,11 @@ pad = { version = "0.1", optional = true }
 unicode-width = { version = "0.1.8", optional = true }
 linefeed = { version = "0.6.0", optional = true }
 rand = { version = "0.8", optional = true }
-structopt = { version = "0.3", optional = true }
+clap = { version = "3.1", optional = true, features = ["derive"] }
 count-zeroes = { version = "0.2.0", optional = true }
 
 [features]
-cli = [ "lazy_static", "ansi_term", "pad", "unicode-width", "linefeed", "rand", "structopt", "count-zeroes" ]
+cli = [ "lazy_static", "ansi_term", "pad", "unicode-width", "linefeed", "rand", "clap", "count-zeroes" ]
 
 [target.'cfg(target_os = "linux")'.dependencies]
 nix = "0.22"

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -438,7 +438,7 @@ pub fn print(opt: &Opt, path: &Path, gpt: &GPT, len: u64, disk_order: bool) -> R
             Column::Sectors => table.add_cell_rtl("Sectors"),
             Column::Size => table.add_cell_rtl("Size"),
             Column::Type => table.add_cell("Type"),
-            Column::GUID => table.add_cell("GUID"),
+            Column::Guid => table.add_cell("GUID"),
             Column::Attributes => table.add_cell("Attributes"),
             Column::Name => table.add_cell("Name"),
         }
@@ -464,7 +464,7 @@ pub fn print(opt: &Opt, path: &Path, gpt: &GPT, len: u64, disk_order: bool) -> R
                 Column::Type => {
                     table.add_cell(p.partition_type_guid.display_partition_type_guid().as_str())
                 }
-                Column::GUID => table.add_cell(p.unique_partition_guid.display_uuid().as_str()),
+                Column::Guid => table.add_cell(p.unique_partition_guid.display_uuid().as_str()),
                 Column::Attributes => table.add_cell(
                     p.attribute_bits
                         .display_attribute_bits(p.partition_type_guid)

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -13,7 +13,7 @@ use self::commands::{execute, print};
 use self::error::*;
 use self::opt::*;
 use self::uuid::generate_random_uuid;
-use clap::StructOpt;
+use clap::Parser;
 #[cfg(target_os = "linux")]
 use gptman::linux::get_sector_size;
 use gptman::GPT;
@@ -34,7 +34,7 @@ macro_rules! main_unwrap {
 }
 
 fn main() {
-    let opt = Opt::from_args();
+    let opt = Opt::parse();
 
     if opt.print {
         let (mut gpt, len) = main_unwrap!(open_disk(&opt));

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -13,13 +13,13 @@ use self::commands::{execute, print};
 use self::error::*;
 use self::opt::*;
 use self::uuid::generate_random_uuid;
+use clap::StructOpt;
 #[cfg(target_os = "linux")]
 use gptman::linux::get_sector_size;
 use gptman::GPT;
 use linefeed::{Interface, ReadResult, Signal};
 use std::fs;
 use std::io::{Seek, SeekFrom};
-use structopt::StructOpt;
 
 macro_rules! main_unwrap {
     ($e:expr) => {{

--- a/src/cli/opt.rs
+++ b/src/cli/opt.rs
@@ -9,7 +9,7 @@ pub enum Column {
     Sectors,
     Size,
     Type,
-    GUID,
+    Guid,
     Attributes,
     Name,
 }

--- a/src/cli/opt.rs
+++ b/src/cli/opt.rs
@@ -2,7 +2,6 @@ use clap::{ArgEnum, Parser};
 use std::path::PathBuf;
 
 #[derive(ArgEnum, Clone, Debug)]
-#[clap(rename_all = "verbatim")]
 pub enum Column {
     Device,
     Start,
@@ -27,7 +26,7 @@ pub struct Opt {
         short = 'o',
         long = "output",
         arg_enum,
-        default_value = "Device,Start,End,Sectors,Size,Type,GUID,Attributes,Name",
+        default_value = "device,start,end,sectors,size,type,guid,attributes,name",
         use_value_delimiter = true
     )]
     pub columns: Vec<Column>,

--- a/src/cli/opt.rs
+++ b/src/cli/opt.rs
@@ -16,7 +16,7 @@ pub enum Column {
 }
 
 #[derive(Parser, Debug)]
-#[clap()]
+#[clap(version)]
 pub struct Opt {
     /// display partitions and exit
     #[clap(short = 'l', long = "list")]

--- a/src/cli/opt.rs
+++ b/src/cli/opt.rs
@@ -48,3 +48,14 @@ pub struct Opt {
     #[clap(short = 'a', long = "align")]
     pub align: Option<u64>,
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn verify_app() {
+        use clap::CommandFactory;
+        Opt::command().debug_assert();
+    }
+}

--- a/src/cli/opt.rs
+++ b/src/cli/opt.rs
@@ -1,35 +1,34 @@
+use clap::{ArgEnum, StructOpt};
 use std::path::PathBuf;
-use structopt::clap::arg_enum;
-use structopt::StructOpt;
 
-arg_enum! {
-    #[derive(Debug)]
-    pub enum Column {
-        Device,
-        Start,
-        End,
-        Sectors,
-        Size,
-        Type,
-        GUID,
-        Attributes,
-        Name,
-    }
+#[derive(ArgEnum, Clone, Debug)]
+#[clap(rename_all = "verbatim")]
+pub enum Column {
+    Device,
+    Start,
+    End,
+    Sectors,
+    Size,
+    Type,
+    GUID,
+    Attributes,
+    Name,
 }
 
 #[derive(StructOpt, Debug)]
 #[structopt()]
 pub struct Opt {
     /// display partitions and exit
-    #[structopt(short = "l", long = "list")]
+    #[structopt(short = 'l', long = "list")]
     pub print: bool,
 
     /// output columns
     #[structopt(
-        short = "o",
+        short = 'o',
         long = "output",
+        arg_enum,
         default_value = "Device,Start,End,Sectors,Size,Type,GUID,Attributes,Name",
-        use_delimiter = true, possible_values = &Column::variants()
+        use_delimiter = true
     )]
     pub columns: Vec<Column>,
 
@@ -38,14 +37,14 @@ pub struct Opt {
     pub device: PathBuf,
 
     /// initialize a new GPT on the disk
-    #[structopt(short = "i", long = "init")]
+    #[structopt(short = 'i', long = "init")]
     pub init: bool,
 
     /// sector size
-    #[structopt(short = "b", long = "sector-size")]
+    #[structopt(short = 'b', long = "sector-size")]
     pub sector_size: Option<u64>,
 
     /// partition alignment
-    #[structopt(short = "a", long = "align")]
+    #[structopt(short = 'a', long = "align")]
     pub align: Option<u64>,
 }

--- a/src/cli/opt.rs
+++ b/src/cli/opt.rs
@@ -1,4 +1,4 @@
-use clap::{ArgEnum, StructOpt};
+use clap::{ArgEnum, Parser};
 use std::path::PathBuf;
 
 #[derive(ArgEnum, Clone, Debug)]
@@ -15,36 +15,36 @@ pub enum Column {
     Name,
 }
 
-#[derive(StructOpt, Debug)]
-#[structopt()]
+#[derive(Parser, Debug)]
+#[clap()]
 pub struct Opt {
     /// display partitions and exit
-    #[structopt(short = 'l', long = "list")]
+    #[clap(short = 'l', long = "list")]
     pub print: bool,
 
     /// output columns
-    #[structopt(
+    #[clap(
         short = 'o',
         long = "output",
         arg_enum,
         default_value = "Device,Start,End,Sectors,Size,Type,GUID,Attributes,Name",
-        use_delimiter = true
+        use_value_delimiter = true
     )]
     pub columns: Vec<Column>,
 
     /// device to open
-    #[structopt(name = "DEVICE", parse(from_os_str))]
+    #[clap(name = "DEVICE", parse(from_os_str))]
     pub device: PathBuf,
 
     /// initialize a new GPT on the disk
-    #[structopt(short = 'i', long = "init")]
+    #[clap(short = 'i', long = "init")]
     pub init: bool,
 
     /// sector size
-    #[structopt(short = 'b', long = "sector-size")]
+    #[clap(short = 'b', long = "sector-size")]
     pub sector_size: Option<u64>,
 
     /// partition alignment
-    #[structopt(short = 'a', long = "align")]
+    #[clap(short = 'a', long = "align")]
     pub align: Option<u64>,
 }


### PR DESCRIPTION
structopt development has moved into clap.

This enables color help by default, unlike in structopt.  It also changes the `--help` output to group flags with other options.

The gptman `-o` option still allows multiple occurrences (`-o Device -o Sectors`) and multiple delimited values (`-o Device,Sectors`), but due to changes in clap defaults, no longer allows multiple values (`-o Device Sectors`).  The latter syntax is weird (e.g. it precludes `gptman -l -o Device /dev/loop0`, with the device path at the end), so I've left it disabled.