### PR TITLE
cargo: Disable CLI by default

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace
+          args: --workspace --all-features
 
   test-windows:
     runs-on: windows-latest
@@ -36,7 +36,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace
+          args: --workspace --all-features
 
   test-macos:
     runs-on: macos-latest
@@ -50,4 +50,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace
+          args: --workspace --all-features

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace
+          args: --workspace --all-features
 
       - name: rustfmt
         uses: actions-rs/cargo@v1
@@ -46,7 +46,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace
+          args: --workspace --all-features
 
   test-macos:
     runs-on: macos-latest
@@ -60,4 +60,4 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
-          args: --workspace
+          args: --workspace --all-features

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --target x86_64-unknown-linux-musl
+          args: --release --all-features --target x86_64-unknown-linux-musl
       - run: strip target/x86_64-unknown-linux-musl/release/gptman
       - uses: actions/upload-artifact@v2
         with:
@@ -35,7 +35,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release --target=x86_64-pc-windows-msvc
+          args: --release --all-features --target=x86_64-pc-windows-msvc
       - uses: actions/upload-artifact@v2
         with:
           name: binary-windows
@@ -50,7 +50,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: --release
+          args: --release --all-features
       - uses: actions/upload-artifact@v2
         with:
           name: binary-osx

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,6 @@ structopt = { version = "0.3", optional = true }
 count-zeroes = { version = "0.2.0", optional = true }
 
 [features]
-default = [ "cli" ]
 cli = [ "lazy_static", "ansi_term", "pad", "unicode-width", "linefeed", "rand", "structopt", "count-zeroes" ]
 
 [target.'cfg(target_os = "linux")'.dependencies]

--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@
 gptman
 ======
 
+A library that allows managing GUID partition tables.
+
 A CLI tool for Linux that allows you to copy a partition from one disk to
 another and more.
-
-A library that allows managing GUID partition tables.
 
 Features
 --------
@@ -51,13 +51,13 @@ Installation
  *  CLI:
 
     ```
-    cargo install gptman
+    cargo install --features=cli gptman
     ```
 
     Statically linked:
 
     ```
-    cargo install --target=x86_64-unknown-linux-musl gptman
+    cargo install --features=cli --target=x86_64-unknown-linux-musl gptman
     ```
 
  *  Library:
@@ -65,7 +65,7 @@ Installation
     Cargo.toml:
     ```toml
     [dependencies]
-    gptman = { version = "0.2.0", default-features = false }
+    gptman = "0.8.0"
     ```
 
 Library Usage


### PR DESCRIPTION
Using gptman as a library appears to be the common case.

This is a breaking change, of course.

xref https://github.com/cecton/gptman/pull/77#issuecomment-1124573550